### PR TITLE
fix: update `recordings` snippets and type fix

### DIFF
--- a/src/api/types/TranscriptsListResponse.ts
+++ b/src/api/types/TranscriptsListResponse.ts
@@ -5,5 +5,5 @@
 import * as Corti from "../index.js";
 
 export interface TranscriptsListResponse {
-    transcripts: Corti.TranscriptsListItem[];
+    transcripts?: Corti.TranscriptsListItem[] | null;
 }

--- a/src/custom/CortiAuth.ts
+++ b/src/custom/CortiAuth.ts
@@ -63,7 +63,7 @@ export class Auth extends FernAuth {
             (await core.Supplier.get(this._options.baseUrl)) ??
             (await core.Supplier.get(this._options.environment)).login,
             await core.Supplier.get(this._options.tenantName),
-            "protocol/openid-connect/token",
+            "protocol/openid-connect/auth",
         ));
 
         authUrl.searchParams.set('response_type', 'code');

--- a/src/custom/CustomStream.ts
+++ b/src/custom/CustomStream.ts
@@ -26,11 +26,12 @@ export class Stream extends FernStream {
         args: Omit<FernStream.ConnectArgs, 'token' | 'tenantName'>,
         configuration?: api.StreamConfig
     ): Promise<StreamSocket> {
-        const ws = await super.connect({
+        const fernWs = await super.connect({
             ...args,
             token: await this._getAuthorizationHeader() || '',
             tenantName: await core.Supplier.get(this._options.tenantName),
-        }) as StreamSocket;
+        });
+        const ws = new StreamSocket({ socket: fernWs.socket });
 
         if (!configuration) {
             return ws;

--- a/src/custom/CustomTranscribe.ts
+++ b/src/custom/CustomTranscribe.ts
@@ -26,11 +26,12 @@ export class Transcribe extends FernTranscribe {
         args: Omit<FernTranscribe.ConnectArgs, 'token' | 'tenantName'> = {},
         configuration?: api.TranscribeConfig
     ): Promise<TranscribeSocket> {
-        const ws = await super.connect({
+        const fernWs = await super.connect({
             ...args,
             token: await this._getAuthorizationHeader() || '',
             tenantName: await core.Supplier.get(this._options.tenantName),
-        }) as TranscribeSocket;
+        });
+        const ws = new TranscribeSocket({ socket: fernWs.socket });
 
         if (!configuration) {
             return ws;

--- a/src/serialization/types/TranscriptsListResponse.ts
+++ b/src/serialization/types/TranscriptsListResponse.ts
@@ -11,11 +11,11 @@ export const TranscriptsListResponse: core.serialization.ObjectSchema<
     serializers.TranscriptsListResponse.Raw,
     Corti.TranscriptsListResponse
 > = core.serialization.object({
-    transcripts: core.serialization.list(TranscriptsListItem),
+    transcripts: core.serialization.list(TranscriptsListItem).optionalNullable(),
 });
 
 export declare namespace TranscriptsListResponse {
     export interface Raw {
-        transcripts: TranscriptsListItem.Raw[];
+        transcripts?: (TranscriptsListItem.Raw[] | null) | null;
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -928,9 +928,9 @@ acorn-globals@^7.0.0:
     acorn-walk "^8.0.2"
 
 acorn-import-phases@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/acorn-import-phases/-/acorn-import-phases-1.0.3.tgz#30394a1dccee5f380aecb8205b8c69b4f7ae688e"
-  integrity sha512-jtKLnfoOzm28PazuQ4dVBcE9Jeo6ha1GAJvq3N0LlNOszmTfx+wSycBehn+FN0RnyeR77IBxN/qVYMw0Rlj0Xw==
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz#16eb850ba99a056cb7cbfe872ffb8972e18c8bd7"
+  integrity sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==
 
 acorn-walk@^8.0.2:
   version "8.3.4"


### PR DESCRIPTION
### Documentation update

1.  returns  when empty, documented this behavior
2. updated  snippets to match current behaviour

### SDK update

1. updated Socket-s logic -- we were returning instance of original class instead of patched one
2. fixed issue with code Authentication -- SDK returned wrong path before
