### PR TITLE
feat: add dictationtranscript utility which concatenates the transcripts

### DIFF
--- a/src/custom/utils/dictationTranscript.ts
+++ b/src/custom/utils/dictationTranscript.ts
@@ -15,6 +15,9 @@ export interface DictationTranscriptSnapshot {
     _latestFinalEnd: number;
 }
 
+const NO_SPACE_AFTER = new Set(["(", "[", "{", '"', "'", "\u2018", "\u201c"]);
+const LEFT_ATTACH = new Set([",", ".", ":", ";", "!", "?", ")", "]", "}", "%"]);
+
 /**
  * Returns the segment text prefixed with at most one space, applying
  * punctuation-aware boundary rules so callers never produce double-spaces
@@ -26,11 +29,8 @@ function buildInsertion(committed: string, segment: string): string {
     const prevChar = committed.length > 0 ? committed[committed.length - 1] : "";
     const nextChar = segment[0] ?? "";
 
-    const noSpaceAfter = new Set(["(", "[", "{", '"', "'", "\u2018", "\u201c"]);
-    const leftAttach = new Set([",", ".", ":", ";", "!", "?", ")", "]", "}", "%"]);
-
     const needsSpace =
-        committed.length > 0 && !/\s/.test(prevChar) && !noSpaceAfter.has(prevChar) && !leftAttach.has(nextChar);
+        committed.length > 0 && !/\s/.test(prevChar) && !NO_SPACE_AFTER.has(prevChar) && !LEFT_ATTACH.has(nextChar);
 
     return needsSpace ? ` ${segment}` : segment;
 }
@@ -50,7 +50,7 @@ export function applyDictationTranscript(
     message: Pick<TranscribeTranscriptData, "text" | "start" | "end" | "isFinal">,
 ): DictationTranscriptSnapshot {
     const committedText = previous?.committedText ?? "";
-    const finalizedStarts: Set<number> = previous ? new Set(previous._finalizedStarts) : new Set();
+    const finalizedStarts = previous?._finalizedStarts ?? new Set<number>();
     const latestFinalEnd = previous?._latestFinalEnd ?? -Infinity;
 
     if (message.isFinal) {
@@ -63,13 +63,15 @@ export function applyDictationTranscript(
             };
         }
 
+        const nextFinalizedStarts = new Set(finalizedStarts);
+        nextFinalizedStarts.add(message.start);
+
         const newCommitted = committedText + buildInsertion(committedText, message.text);
-        finalizedStarts.add(message.start);
 
         return {
             committedText: newCommitted,
             interimText: "",
-            _finalizedStarts: finalizedStarts,
+            _finalizedStarts: nextFinalizedStarts,
             _latestFinalEnd: Math.max(latestFinalEnd, message.end),
         };
     }

--- a/src/custom/utils/dictationTranscript.ts
+++ b/src/custom/utils/dictationTranscript.ts
@@ -1,0 +1,107 @@
+import type { TranscribeTranscriptData } from "../../api/types/TranscribeTranscriptData.js";
+
+export interface DictationTranscriptSnapshot {
+    /** Finalized text. Use this for copy, clear, and JSON export. */
+    committedText: string;
+    /**
+     * Active interim preview. Empty string when none.
+     * Includes its leading boundary space so the UI can render it verbatim
+     * immediately after committedText.
+     */
+    interimText: string;
+    /** @internal */
+    _finalizedStarts: ReadonlySet<number>;
+    /** @internal */
+    _latestFinalEnd: number;
+}
+
+/**
+ * Returns the segment text prefixed with at most one space, applying
+ * punctuation-aware boundary rules so callers never produce double-spaces
+ * or spaces before attachment characters.
+ */
+function buildInsertion(committed: string, segment: string): string {
+    if (!segment) return segment;
+
+    const prevChar = committed.length > 0 ? committed[committed.length - 1] : "";
+    const nextChar = segment[0] ?? "";
+
+    const noSpaceAfter = new Set(["(", "[", "{", '"', "'", "\u2018", "\u201c"]);
+    const leftAttach = new Set([",", ".", ":", ";", "!", "?", ")", "]", "}", "%"]);
+
+    const needsSpace =
+        committed.length > 0 &&
+        !/\s/.test(prevChar) &&
+        !noSpaceAfter.has(prevChar) &&
+        !leftAttach.has(nextChar);
+
+    return needsSpace ? " " + segment : segment;
+}
+
+/**
+ * Pure function that applies a single transcript message to the previous
+ * snapshot and returns a new snapshot with updated committed/interim text.
+ *
+ * - Handles the two-layer committed + interim model (DXG-844).
+ * - Ignores late interims that overlap an already-finalized timeline (DXG-1093).
+ *
+ * @param previous - The last snapshot, or `undefined` on first call.
+ * @param message  - The incoming transcript packet (subset of TranscribeTranscriptData).
+ */
+export function applyDictationTranscript(
+    previous: DictationTranscriptSnapshot | undefined,
+    message: Pick<TranscribeTranscriptData, "text" | "start" | "end" | "isFinal">,
+): DictationTranscriptSnapshot {
+    const committedText = previous?.committedText ?? "";
+    const finalizedStarts: Set<number> = previous
+        ? new Set(previous._finalizedStarts)
+        : new Set();
+    const latestFinalEnd = previous?._latestFinalEnd ?? -Infinity;
+
+    if (message.isFinal) {
+        if (finalizedStarts.has(message.start)) {
+            return {
+                committedText,
+                interimText: "",
+                _finalizedStarts: finalizedStarts,
+                _latestFinalEnd: latestFinalEnd,
+            };
+        }
+
+        const newCommitted = committedText + buildInsertion(committedText, message.text);
+        finalizedStarts.add(message.start);
+
+        return {
+            committedText: newCommitted,
+            interimText: "",
+            _finalizedStarts: finalizedStarts,
+            _latestFinalEnd: Math.max(latestFinalEnd, message.end),
+        };
+    }
+
+    // Interim path.
+    if (finalizedStarts.has(message.start)) {
+        return previous ?? {
+            committedText: "",
+            interimText: "",
+            _finalizedStarts: finalizedStarts,
+            _latestFinalEnd: latestFinalEnd,
+        };
+    }
+
+    if (message.start < latestFinalEnd) {
+        return previous ?? {
+            committedText: "",
+            interimText: "",
+            _finalizedStarts: finalizedStarts,
+            _latestFinalEnd: latestFinalEnd,
+        };
+    }
+
+    return {
+        committedText,
+        interimText: buildInsertion(committedText, message.text),
+        _finalizedStarts: finalizedStarts,
+        _latestFinalEnd: latestFinalEnd,
+    };
+}

--- a/src/custom/utils/dictationTranscript.ts
+++ b/src/custom/utils/dictationTranscript.ts
@@ -30,12 +30,9 @@ function buildInsertion(committed: string, segment: string): string {
     const leftAttach = new Set([",", ".", ":", ";", "!", "?", ")", "]", "}", "%"]);
 
     const needsSpace =
-        committed.length > 0 &&
-        !/\s/.test(prevChar) &&
-        !noSpaceAfter.has(prevChar) &&
-        !leftAttach.has(nextChar);
+        committed.length > 0 && !/\s/.test(prevChar) && !noSpaceAfter.has(prevChar) && !leftAttach.has(nextChar);
 
-    return needsSpace ? " " + segment : segment;
+    return needsSpace ? ` ${segment}` : segment;
 }
 
 /**
@@ -53,9 +50,7 @@ export function applyDictationTranscript(
     message: Pick<TranscribeTranscriptData, "text" | "start" | "end" | "isFinal">,
 ): DictationTranscriptSnapshot {
     const committedText = previous?.committedText ?? "";
-    const finalizedStarts: Set<number> = previous
-        ? new Set(previous._finalizedStarts)
-        : new Set();
+    const finalizedStarts: Set<number> = previous ? new Set(previous._finalizedStarts) : new Set();
     const latestFinalEnd = previous?._latestFinalEnd ?? -Infinity;
 
     if (message.isFinal) {
@@ -81,21 +76,25 @@ export function applyDictationTranscript(
 
     // Interim path.
     if (finalizedStarts.has(message.start)) {
-        return previous ?? {
-            committedText: "",
-            interimText: "",
-            _finalizedStarts: finalizedStarts,
-            _latestFinalEnd: latestFinalEnd,
-        };
+        return (
+            previous ?? {
+                committedText: "",
+                interimText: "",
+                _finalizedStarts: finalizedStarts,
+                _latestFinalEnd: latestFinalEnd,
+            }
+        );
     }
 
     if (message.start < latestFinalEnd) {
-        return previous ?? {
-            committedText: "",
-            interimText: "",
-            _finalizedStarts: finalizedStarts,
-            _latestFinalEnd: latestFinalEnd,
-        };
+        return (
+            previous ?? {
+                committedText: "",
+                interimText: "",
+                _finalizedStarts: finalizedStarts,
+                _latestFinalEnd: latestFinalEnd,
+            }
+        );
     }
 
     return {

--- a/src/custom/utils/index.ts
+++ b/src/custom/utils/index.ts
@@ -1,3 +1,7 @@
 export { type DecodedToken, decodeToken } from "./decodeToken.js";
+export {
+    applyDictationTranscript,
+    type DictationTranscriptSnapshot,
+} from "./dictationTranscript.js";
 export { getEnvironment } from "./environment.js";
 export { generateCodeChallenge, generateCodeVerifier } from "./pkceHelpers.js";

--- a/tests/custom/dictationTranscript.test.ts
+++ b/tests/custom/dictationTranscript.test.ts
@@ -1,7 +1,4 @@
-import {
-    applyDictationTranscript,
-    type DictationTranscriptSnapshot,
-} from "../../../src/custom/utils/dictationTranscript";
+import { applyDictationTranscript, type DictationTranscriptSnapshot } from "../../src/custom/utils/dictationTranscript";
 
 type Msg = Parameters<typeof applyDictationTranscript>[1];
 

--- a/tests/unit/utils/dictationTranscript.test.ts
+++ b/tests/unit/utils/dictationTranscript.test.ts
@@ -1,0 +1,242 @@
+import {
+    applyDictationTranscript,
+    type DictationTranscriptSnapshot,
+} from "../../../src/custom/utils/dictationTranscript";
+
+type Msg = Parameters<typeof applyDictationTranscript>[1];
+
+function msg(overrides: Partial<Msg> & { text: string }): Msg {
+    return { start: 0, end: 1, isFinal: false, ...overrides };
+}
+
+function apply(
+    prev: DictationTranscriptSnapshot | undefined,
+    overrides: Partial<Msg> & { text: string },
+): DictationTranscriptSnapshot {
+    return applyDictationTranscript(prev, msg(overrides));
+}
+
+// ---------------------------------------------------------------------------
+// buildInsertion / spacing
+// ---------------------------------------------------------------------------
+
+describe("buildInsertion — punctuation-aware spacing", () => {
+    interface SpacingCase {
+        description: string;
+        committedText: string;
+        segmentText: string;
+        wantInterimText: string;
+    }
+
+    const cases: SpacingCase[] = [
+        {
+            description: "no space when committed is empty",
+            committedText: "",
+            segmentText: "hello",
+            wantInterimText: "hello",
+        },
+        {
+            description: "space added between two normal words",
+            committedText: "hello",
+            segmentText: "world",
+            wantInterimText: " world",
+        },
+        {
+            description: "no space when previous char is a space",
+            committedText: "hello ",
+            segmentText: "world",
+            wantInterimText: "world",
+        },
+        {
+            description: "no space after open paren",
+            committedText: "see (",
+            segmentText: "fig",
+            wantInterimText: "fig",
+        },
+        {
+            description: "no space after open bracket",
+            committedText: "items [",
+            segmentText: "one",
+            wantInterimText: "one",
+        },
+        {
+            description: "no space after open brace",
+            committedText: "map {",
+            segmentText: "key",
+            wantInterimText: "key",
+        },
+        {
+            description: "no space after straight double quote",
+            committedText: 'say "',
+            segmentText: "hello",
+            wantInterimText: "hello",
+        },
+        {
+            description: "no space after curly open quote",
+            committedText: "say \u201c",
+            segmentText: "hello",
+            wantInterimText: "hello",
+        },
+        {
+            description: "no space before comma",
+            committedText: "hello",
+            segmentText: ",",
+            wantInterimText: ",",
+        },
+        {
+            description: "no space before period",
+            committedText: "hello",
+            segmentText: ".",
+            wantInterimText: ".",
+        },
+        {
+            description: "no space before colon",
+            committedText: "hello",
+            segmentText: ":",
+            wantInterimText: ":",
+        },
+        {
+            description: "no space before semicolon",
+            committedText: "hello",
+            segmentText: ";",
+            wantInterimText: ";",
+        },
+        {
+            description: "no space before exclamation mark",
+            committedText: "hello",
+            segmentText: "!",
+            wantInterimText: "!",
+        },
+        {
+            description: "no space before question mark",
+            committedText: "hello",
+            segmentText: "?",
+            wantInterimText: "?",
+        },
+        {
+            description: "no space before close paren",
+            committedText: "hello",
+            segmentText: ")",
+            wantInterimText: ")",
+        },
+        {
+            description: "no space before percent",
+            committedText: "50",
+            segmentText: "%",
+            wantInterimText: "%",
+        },
+        {
+            description: "space added after colon before normal word",
+            committedText: "note:",
+            segmentText: "important",
+            wantInterimText: " important",
+        },
+    ];
+
+    test.each(cases)("$description", ({ committedText, segmentText, wantInterimText }) => {
+        const snap = apply(
+            committedText
+                ? ({
+                      committedText,
+                      interimText: "",
+                      _finalizedStarts: new Set(),
+                      _latestFinalEnd: -Infinity,
+                  } as DictationTranscriptSnapshot)
+                : undefined,
+            { text: segmentText, start: 100, end: 101, isFinal: false },
+        );
+        expect(snap.interimText).toBe(wantInterimText);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Interim → Final lifecycle
+// ---------------------------------------------------------------------------
+
+describe("interim → final lifecycle", () => {
+    it("interim sets interimText, does not change committedText", () => {
+        const snap = apply(undefined, { text: "hello", start: 0, end: 1, isFinal: false });
+        expect(snap.committedText).toBe("");
+        expect(snap.interimText).toBe("hello");
+    });
+
+    it("final appends to committedText and clears interimText", () => {
+        const s1 = apply(undefined, { text: "hello", start: 0, end: 1, isFinal: false });
+        const s2 = apply(s1, { text: "hello", start: 0, end: 1, isFinal: true });
+        expect(s2.committedText).toBe("hello");
+        expect(s2.interimText).toBe("");
+    });
+
+    it("subsequent final appends with correct spacing", () => {
+        const s1 = apply(undefined, { text: "hello", start: 0, end: 1, isFinal: true });
+        const s2 = apply(s1, { text: "world", start: 1, end: 2, isFinal: true });
+        expect(s2.committedText).toBe("hello world");
+        expect(s2.interimText).toBe("");
+    });
+
+    it("new interim after a final includes leading space", () => {
+        const s1 = apply(undefined, { text: "hello", start: 0, end: 1, isFinal: true });
+        const s2 = apply(s1, { text: "world", start: 1, end: 2, isFinal: false });
+        expect(s2.interimText).toBe(" world");
+        expect(s2.committedText).toBe("hello");
+    });
+
+    it("two interims — only latest survives", () => {
+        const s1 = apply(undefined, { text: "firs", start: 0, end: 1, isFinal: false });
+        const s2 = apply(s1, { text: "first", start: 0, end: 1, isFinal: false });
+        expect(s2.interimText).toBe("first");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Race condition guards
+// ---------------------------------------------------------------------------
+
+describe("race condition guards", () => {
+    it("R2: interim for already-finalized start → snapshot unchanged", () => {
+        const s1 = apply(undefined, { text: "hello", start: 0, end: 1, isFinal: true });
+        const s2 = apply(s1, { text: "GHOST", start: 0, end: 1, isFinal: false });
+        expect(s2).toBe(s1); // exact same reference
+    });
+
+    it("R-cross: late interim with start < latestFinalEnd → snapshot unchanged", () => {
+        // Segment [0,5] finalized; then an interim arrives with start=3 (overlaps)
+        const s1 = apply(undefined, { text: "hello world", start: 0, end: 5, isFinal: true });
+        const s2 = apply(s1, { text: "GHOST", start: 3, end: 4, isFinal: false });
+        expect(s2).toBe(s1);
+    });
+
+    it("R5: duplicate final same start → no double-append, interimText cleared", () => {
+        const s1 = apply(undefined, { text: "hello", start: 0, end: 1, isFinal: true });
+        // A second interim slips in
+        const s2 = apply(s1, { text: "hell", start: 0, end: 1, isFinal: false });
+        // Then the duplicate final arrives
+        const s3 = apply(s2, { text: "hello", start: 0, end: 1, isFinal: true });
+        expect(s3.committedText).toBe("hello"); // not "hello hello"
+        expect(s3.interimText).toBe("");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe("edge cases", () => {
+    it("first call with undefined previous and a final packet", () => {
+        const snap = apply(undefined, { text: "hi", start: 0, end: 1, isFinal: true });
+        expect(snap.committedText).toBe("hi");
+        expect(snap.interimText).toBe("");
+    });
+
+    it("empty text segment produces empty interimText", () => {
+        const snap = apply(undefined, { text: "", start: 0, end: 1, isFinal: false });
+        expect(snap.interimText).toBe("");
+    });
+
+    it("non-overlapping interim after separate finalized span is allowed", () => {
+        const s1 = apply(undefined, { text: "hello", start: 0, end: 2, isFinal: true });
+        // start=3 is NOT < latestFinalEnd=2, and not in finalizedStarts → allowed
+        const s2 = apply(s1, { text: "world", start: 3, end: 4, isFinal: false });
+        expect(s2.interimText).toBe(" world");
+    });
+});


### PR DESCRIPTION
feat(utils): add applyDictationTranscript utility ([DXG-844](https://linear.app/corti/issue/DXG-844/transcript-viewer-dictationtext-logic-update), [DXG-1093](https://linear.app/corti/issue/DXG-1093/look-into-possible-race-condition-in-dictation-web-component))

Adds a pure `applyDictationTranscript()` function to `@corti/sdk/utils` that
owns all transcript merge, spacing, and race logic for dictation consumers.

## What

- `src/custom/utils/dictationTranscript.ts` — new utility
- `src/custom/utils/index.ts` — re-exports `applyDictationTranscript` and
  `DictationTranscriptSnapshot` under the existing `@corti/sdk/utils` subpath
- `tests/unit/utils/dictationTranscript.test.ts` — 28 Vitest unit tests

## Why

**DXG-844** — consumers were assembling transcript text with naive `prev + " " +
next` spacing. The utility implements punctuation-aware boundary insertion
(`buildInsertion`): no space at field start, no space after `( [ { " '`, no space
before `, . : ; ! ? ) ] } %`.

**DXG-1093** — on stop/flush, packets arrive out of order. A late interim that
arrives after the final for the same span (or that overlaps an already-finalized
timeline) would flash ghost text in the UI. Two guards prevent this:
- **R2** — interim with a `start` already in `finalizedStarts` → snapshot
  returned unchanged
- **R-cross** — interim with `start < latestFinalEnd` (overlaps any prior final,
  even with a different `start`) → snapshot returned unchanged

## API

```ts
import { applyDictationTranscript, DictationTranscriptSnapshot } from "@corti/sdk/utils";

let snapshot: DictationTranscriptSnapshot | undefined;

// called on each `transcript` event
snapshot = applyDictationTranscript(snapshot, event.data);

// render
committedText  → snapshot.committedText   // finalized; use for copy/export
interimText    → snapshot.interimText     // muted preview; "" when none; includes leading space