### PR TITLE
feat: add public getEnvironmentUrls() method to CortiClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 .DS_Store
-/distpackage-lock.json
+/dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 .DS_Store
-/dist
+/distpackage-lock.json

--- a/src/custom/CortiClient.ts
+++ b/src/custom/CortiClient.ts
@@ -107,7 +107,9 @@ export class CortiClient extends BaseCortiClient {
     public getEnvironmentUrls = async (): Promise<environments.CortiEnvironmentUrls> => {
         const env = await core.Supplier.get(this._options.environment);
         const baseUrl = await core.Supplier.get(this._options.baseUrl);
-        return baseUrl != null ? { ...env, base: baseUrl } : env;
+        // baseUrl overrides both REST (env.base) and WebSocket (env.wss) endpoints;
+        // login and agents are always resolved from the environment.
+        return baseUrl != null ? { ...env, base: baseUrl, wss: baseUrl } : env;
     };
 
     /**

--- a/src/custom/CortiClient.ts
+++ b/src/custom/CortiClient.ts
@@ -92,6 +92,25 @@ export class CortiClient extends BaseCortiClient {
     }
 
     /**
+     * Returns the base REST API URL the client is configured to use.
+     *
+     * Resolves `baseUrl` when explicitly set, otherwise returns the `base` URL
+     * derived from the configured environment.
+     *
+     * @example
+     * ```typescript
+     * const client = new CortiClient({ environment: "eu", ... });
+     * console.log(await client.getBaseUrl()); // "https://api.eu.corti.app/v2"
+     * ```
+     */
+    public getBaseUrl = async (): Promise<string> => {
+        return (
+            (await core.Supplier.get(this._options.baseUrl)) ??
+            (await core.Supplier.get(this._options.environment)).base
+        );
+    };
+
+    /**
      * Retrieves authentication headers for API requests.
      *
      * This method returns a Headers object containing the Authorization header with a valid

--- a/src/custom/CortiClient.ts
+++ b/src/custom/CortiClient.ts
@@ -105,10 +105,11 @@ export class CortiClient extends BaseCortiClient {
      * ```
      */
     public getEnvironmentUrls = async (): Promise<environments.CortiEnvironmentUrls> => {
-        const env = await core.Supplier.get(this._options.environment);
         const baseUrl = await core.Supplier.get(this._options.baseUrl);
         // baseUrl is a universal override: all generated clients use `baseUrl ?? env.<field>`.
-        return baseUrl != null ? { base: baseUrl, wss: baseUrl, login: baseUrl, agents: baseUrl } : env;
+        // Resolve environment only in the fallback path to avoid triggering auth discovery needlessly.
+        if (baseUrl != null) return { base: baseUrl, wss: baseUrl, login: baseUrl, agents: baseUrl };
+        return await core.Supplier.get(this._options.environment);
     };
 
     /**

--- a/src/custom/CortiClient.ts
+++ b/src/custom/CortiClient.ts
@@ -107,9 +107,8 @@ export class CortiClient extends BaseCortiClient {
     public getEnvironmentUrls = async (): Promise<environments.CortiEnvironmentUrls> => {
         const env = await core.Supplier.get(this._options.environment);
         const baseUrl = await core.Supplier.get(this._options.baseUrl);
-        // baseUrl overrides both REST (env.base) and WebSocket (env.wss) endpoints;
-        // login and agents are always resolved from the environment.
-        return baseUrl != null ? { ...env, base: baseUrl, wss: baseUrl } : env;
+        // baseUrl is a universal override: all generated clients use `baseUrl ?? env.<field>`.
+        return baseUrl != null ? { base: baseUrl, wss: baseUrl, login: baseUrl, agents: baseUrl } : env;
     };
 
     /**

--- a/src/custom/CortiClient.ts
+++ b/src/custom/CortiClient.ts
@@ -92,22 +92,22 @@ export class CortiClient extends BaseCortiClient {
     }
 
     /**
-     * Returns the base REST API URL the client is configured to use.
+     * Returns the full set of URLs the client is configured to use.
      *
-     * Resolves `baseUrl` when explicitly set, otherwise returns the `base` URL
-     * derived from the configured environment.
+     * If a custom `baseUrl` was provided it overrides the `base` field; all
+     * other URLs are derived from the configured environment.
      *
      * @example
      * ```typescript
      * const client = new CortiClient({ environment: "eu", ... });
-     * console.log(await client.getBaseUrl()); // "https://api.eu.corti.app/v2"
+     * const urls = await client.getEnvironmentUrls();
+     * // { base: "https://api.eu.corti.app/v2", wss: "wss://...", login: "https://...", agents: "https://..." }
      * ```
      */
-    public getBaseUrl = async (): Promise<string> => {
-        return (
-            (await core.Supplier.get(this._options.baseUrl)) ??
-            (await core.Supplier.get(this._options.environment)).base
-        );
+    public getEnvironmentUrls = async (): Promise<environments.CortiEnvironmentUrls> => {
+        const env = await core.Supplier.get(this._options.environment);
+        const baseUrl = await core.Supplier.get(this._options.baseUrl);
+        return baseUrl != null ? { ...env, base: baseUrl } : env;
     };
 
     /**

--- a/tests/custom/cortiClient.getEnvironmentUrls.test.ts
+++ b/tests/custom/cortiClient.getEnvironmentUrls.test.ts
@@ -1,0 +1,59 @@
+import { CortiClient } from "../../src";
+
+// CC auth skips JWT decoding in resolveClientOptions, so it works with any environment value.
+const CC_AUTH = { auth: { clientId: "test", clientSecret: "test" }, tenantName: "test" };
+// Bearer auth with a fake token works when isProxyMode() returns true (baseUrl or full URL object set).
+const BEARER_AUTH = { auth: { accessToken: "fake-token" } };
+
+function makeClient(overrides: object): CortiClient {
+    return new CortiClient(overrides as ConstructorParameters<typeof CortiClient>[0]);
+}
+
+describe("cortiClient.getEnvironmentUrls", () => {
+    describe("named environment string", () => {
+        it("returns correctly-shaped URLs for a known region", async () => {
+            const client = makeClient({ ...CC_AUTH, environment: "eu" });
+            const urls = await client.getEnvironmentUrls();
+
+            expect(urls.base).toBe("https://api.eu.corti.app/v2");
+            expect(urls.wss).toBe("wss://api.eu.corti.app/audio-bridge/v2");
+            expect(urls.login).toBe("https://auth.eu.corti.app/realms");
+            expect(urls.agents).toBe("https://api.eu.corti.app");
+        });
+    });
+
+    describe("explicit CortiEnvironmentUrls object", () => {
+        it("passes the object through unchanged", async () => {
+            const envUrls = {
+                base: "https://api.custom.example.com/v2",
+                wss: "wss://api.custom.example.com/audio",
+                login: "https://auth.custom.example.com/realms",
+                agents: "https://api.custom.example.com",
+            };
+            const client = makeClient({ ...BEARER_AUTH, environment: envUrls });
+            const urls = await client.getEnvironmentUrls();
+
+            expect(urls).toEqual(envUrls);
+        });
+    });
+
+    describe("baseUrl override", () => {
+        it("overrides base and wss but keeps login and agents from the environment", async () => {
+            const client = makeClient({ ...CC_AUTH, environment: "eu", baseUrl: "https://proxy.example.com" });
+            const urls = await client.getEnvironmentUrls();
+
+            expect(urls.base).toBe("https://proxy.example.com");
+            expect(urls.wss).toBe("https://proxy.example.com");
+            expect(urls.login).toBe("https://auth.eu.corti.app/realms");
+            expect(urls.agents).toBe("https://api.eu.corti.app");
+        });
+
+        it("without an environment, base and wss reflect the baseUrl", async () => {
+            const client = makeClient({ ...BEARER_AUTH, baseUrl: "https://proxy.example.com" });
+            const urls = await client.getEnvironmentUrls();
+
+            expect(urls.base).toBe("https://proxy.example.com");
+            expect(urls.wss).toBe("https://proxy.example.com");
+        });
+    });
+});

--- a/tests/custom/cortiClient.getEnvironmentUrls.test.ts
+++ b/tests/custom/cortiClient.getEnvironmentUrls.test.ts
@@ -38,14 +38,14 @@ describe("cortiClient.getEnvironmentUrls", () => {
     });
 
     describe("baseUrl override", () => {
-        it("overrides base and wss but keeps login and agents from the environment", async () => {
+        it("overrides all four fields since all generated clients use baseUrl ?? env.<field>", async () => {
             const client = makeClient({ ...CC_AUTH, environment: "eu", baseUrl: "https://proxy.example.com" });
             const urls = await client.getEnvironmentUrls();
 
             expect(urls.base).toBe("https://proxy.example.com");
             expect(urls.wss).toBe("https://proxy.example.com");
-            expect(urls.login).toBe("https://auth.eu.corti.app/realms");
-            expect(urls.agents).toBe("https://api.eu.corti.app");
+            expect(urls.login).toBe("https://proxy.example.com");
+            expect(urls.agents).toBe("https://proxy.example.com");
         });
 
         it("without an environment, base and wss reflect the baseUrl", async () => {


### PR DESCRIPTION
## feat: add public `getEnvironmentUrls()` method to `CortiClient`

### Summary

Adds a `getEnvironmentUrls(): Promise<CortiEnvironmentUrls>` method to `CortiClient`, giving callers a supported way to inspect the URLs the client is configured to use without reaching into the protected `_options` property.

Returns the full `CortiEnvironmentUrls` shape:

| Field | Used by |
|---|---|
| `base` | All REST resource clients |
| `wss` | Stream and Transcribe WebSocket clients |
| `login` | Auth token endpoint |
| `agents` | Agents API client |

### Behaviour

All generated clients follow the same `baseUrl ?? env.<field>` resolution pattern, so this method mirrors that faithfully:

- **No `baseUrl` set** — returns the environment URLs directly (resolved from the named region string or explicit `CortiEnvironmentUrls` object passed at construction)
- **`baseUrl` set** — returns `baseUrl` for all four fields, since every client prefers it over the environment URL
- **`baseUrl` is evaluated first** — the environment supplier is only awaited in the fallback path, avoiding an unnecessary `refreshAccessToken` call on proxy/`baseUrl`-only clients where the environment is backed by a token-discovery promise

### Tests

Unit tests added in `tests/custom/cortiClient.getEnvironmentUrls.test.ts` covering:
- Named environment string (e.g. `"eu"`) produces the correct URL shape
- Explicit `CortiEnvironmentUrls` object passes through unchanged
- `baseUrl` + environment: all four fields reflect `baseUrl`
- `baseUrl`-only (proxy mode): `base` and `wss` reflect `baseUrl`