### PR TITLE
test: skip agents context tests pending backend fix

### DIFF
--- a/tests/custom/agents.deleteContext.integration.ts
+++ b/tests/custom/agents.deleteContext.integration.ts
@@ -64,7 +64,7 @@ describe("cortiClient.agents.deleteContext", () => {
             );
         });
 
-        // Skipped: agents team is fixing a regression where the endpoint stopped validating the agent ID
+        // FIXME: re-enable when agents team fixes the regression where the endpoint stopped validating the agent ID
         it.skip("should throw error when agent ID does not exist", async () => {
             expect.assertions(1);
 

--- a/tests/custom/agents.deleteContext.integration.ts
+++ b/tests/custom/agents.deleteContext.integration.ts
@@ -64,7 +64,8 @@ describe("cortiClient.agents.deleteContext", () => {
             );
         });
 
-        it("should throw error when agent ID does not exist", async () => {
+        // Skipped: agents team is fixing a regression where the endpoint stopped validating the agent ID
+        it.skip("should throw error when agent ID does not exist", async () => {
             expect.assertions(1);
 
             const agent = await createTestAgent(cortiClient);

--- a/tests/custom/agents.getContext.integration.ts
+++ b/tests/custom/agents.getContext.integration.ts
@@ -136,7 +136,8 @@ describe("cortiClient.agents.getContext", () => {
             await expect(cortiClient.agents.getContext(agent.id, "invalid-uuid")).rejects.toThrow("Status code: 400");
         });
 
-        it("should throw error when agent ID does not exist", async () => {
+        // Skipped: agents team is fixing a regression where the endpoint stopped validating the agent ID
+        it.skip("should throw error when agent ID does not exist", async () => {
             expect.assertions(1);
 
             const agent = await createTestAgent(cortiClient);

--- a/tests/custom/agents.getContext.integration.ts
+++ b/tests/custom/agents.getContext.integration.ts
@@ -136,7 +136,7 @@ describe("cortiClient.agents.getContext", () => {
             await expect(cortiClient.agents.getContext(agent.id, "invalid-uuid")).rejects.toThrow("Status code: 400");
         });
 
-        // Skipped: agents team is fixing a regression where the endpoint stopped validating the agent ID
+        // FIXME: re-enable when agents team fixes the regression where the endpoint stopped validating the agent ID
         it.skip("should throw error when agent ID does not exist", async () => {
             expect.assertions(1);
 


### PR DESCRIPTION
Skips two integration test cases while the agents team fixes a backend regression.

`getContext` and `deleteContext` on `/agents/{id}/v1/contexts/{contextId}` stopped validating the `{id}` path parameter around June 26 — both endpoints now resolve successfully for any agent ID as long as the context ID is valid. The spec still documents 404 for this case; the agents team has confirmed it's a regression and is investigating.

Tests can be un-skipped once the backend fix ships.